### PR TITLE
add IT to show a checker errors affects EFFECTIVELY_FINAL in subsequent source files

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -2274,6 +2274,10 @@ public class ASTHelpers {
 
   /** Returns whether {@code symbol} is final or effectively final. */
   public static boolean isConsideredFinal(Symbol symbol) {
+    long flags = symbol.flags();
+    boolean isEffectivelyFinal = (flags & Flags.EFFECTIVELY_FINAL) != 0;
+    System.out.println(
+        symbol + " (effectivelyFinal: " + isEffectivelyFinal + ", flags: " + flags + ")");
     return (symbol.flags() & (Flags.FINAL | Flags.EFFECTIVELY_FINAL)) != 0;
   }
 

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -57,9 +57,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.lang.model.element.Name;
 import javax.tools.Diagnostic;
+import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -617,6 +619,89 @@ public class ErrorProneCompilerIntegrationTest {
         return NO_MATCH;
       }
     }
+  }
+
+  @Test
+  public void checkerBugGood() {
+    runTest("WARN", List.of(1, 2, 3));
+    runTest("WARN", List.of(1, 3, 2));
+    runTest("WARN", List.of(2, 1, 3));
+    runTest("WARN", List.of(2, 3, 1));
+    runTest("WARN", List.of(3, 1, 2));
+    runTest("WARN", List.of(3, 2, 1));
+
+    // fails if 3 comes before 2
+
+    runTest("ERROR", List.of(1, 2, 3));
+    // FAIL: runTest("ERROR", List.of(1, 3, 2));
+    runTest("ERROR", List.of(2, 1, 3));
+    runTest("ERROR", List.of(2, 3, 1));
+    // FAIL: runTest("ERROR", List.of(3, 1, 2));
+    // FAIL: runTest("ERROR", List.of(3, 2, 1));
+  }
+
+  @Test
+  public void checkerBugBad1() {
+    runTest("ERROR", List.of(1, 3, 2));
+  }
+
+  @Test
+  public void checkerBugBad2() {
+    runTest("ERROR", List.of(3, 1, 2));
+  }
+
+  @Test
+  public void checkerBugBad3() {
+    runTest("ERROR", List.of(3, 2, 1));
+  }
+
+  private void runTest(String unusedVariableSeverity, List<Integer> fileOrder) {
+    JavaFileObject file1 = forSourceLines("GenericException.java", """
+        package test;
+        import com.google.errorprone.annotations.FormatMethod;
+        public class GenericException extends Exception {
+          @FormatMethod
+          public GenericException(String message1, Object... args1) {
+            super(String.format(message1, args1));
+          }
+        }
+        """);
+    JavaFileObject file2 = forSourceLines("SpecialException.java", """
+        package test;
+        import com.google.errorprone.annotations.FormatMethod;
+        public class SpecialException extends GenericException {
+          @FormatMethod
+          public SpecialException(String message2, Object... args2) {
+            super(message2, args2);
+          }
+        }
+        """);
+    JavaFileObject file3 = forSourceLines("Violation.java", """
+        package test;
+        public class Violation {
+          public void methodWithViolation() {
+            int x = 0;
+          }
+        }
+        """);
+
+    List<JavaFileObject> allFiles = Arrays.asList(file1, file2, file3);
+    List<JavaFileObject> sources = fileOrder.stream().map(i -> allFiles.get(i - 1)).toList();
+
+    System.out.println("sources files: " + sources.stream()
+        .map(FileObject::getName)
+        .collect(Collectors.joining(", ")));
+
+    String[] args = {
+        "-Xep:UnusedVariable:" + unusedVariableSeverity,
+        "-Xep:FormatStringAnnotation:ERROR"
+    };
+    compiler = compilerBuilder.build();
+    compiler.compile(args, sources);
+    outputStream.flush();
+    String output = diagnosticHelper.getDiagnostics().toString();
+    assertThat(output).contains(": [UnusedVariable]");
+    assertThat(output).doesNotContain(": [FormatStringAnnotation]");
   }
 
   @Test


### PR DESCRIPTION
`checkerBugGood` passes and its output always shows flags like this:
```
sources files: /GenericException.java, /Violation.java, /SpecialException.java
message1 (effectivelyFinal: true, flags: 2207613190144)
args1 (effectivelyFinal: true, flags: 2224793059328)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
message2 (effectivelyFinal: true, flags: 2207613190144)
args2 (effectivelyFinal: true, flags: 2224793059328)
message2 (effectivelyFinal: true, flags: 2207613190144)
```

`checkerBugBad1` fails with:
```
expected not to contain:
    : [FormatStringAnnotation]
but was:
    [/Violation.java:4: error: [UnusedVariable] The local variable 'x' is never read.
        int x = 0;
            ^
        (see https://errorprone.info/bugpattern/UnusedVariable)
      Did you mean to remove this line?, /SpecialException.java:6: error: [FormatStringAnnotation] All variables passed as @FormatString must be final or effectively final
        super(message2, args2);
             ^
        (see https://errorprone.info/bugpattern/FormatStringAnnotation)]
```
and output:
```
sources files: /GenericException.java, /Violation.java, /SpecialException.java
message1 (effectivelyFinal: true, flags: 2207613190144)
args1 (effectivelyFinal: true, flags: 2224793059328)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
message2 (effectivelyFinal: false, flags: 8589934592)
args2 (effectivelyFinal: false, flags: 25769803776)
message2 (effectivelyFinal: false, flags: 8589934592)
```

note how `message1` from `GenericException.java` has the same flags as usual, but `message2` from `SpecialException.java` is no longer effectively final... because it comes after `Violation.java` ?

`checkerBugBad2` fails with output:
```
sources files: /Violation.java, /GenericException.java, /SpecialException.java
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
message1 (effectivelyFinal: false, flags: 8589934592)
args1 (effectivelyFinal: false, flags: 25769803776)
message2 (effectivelyFinal: false, flags: 8589934592)
args2 (effectivelyFinal: false, flags: 25769803776)
message2 (effectivelyFinal: false, flags: 8589934592)
```

note how now both `message1` from `GenericException.java` and `message2` from `SpecialException.java` are no longer effectively final... because they both come after `Violation.java` ?

`checkerBugBad3` fails with output:
```
sources files: /Violation.java, /SpecialException.java, /GenericException.java
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
x (effectivelyFinal: true, flags: 2199023517696)
message2 (effectivelyFinal: false, flags: 8589934592)
args2 (effectivelyFinal: false, flags: 25769803776)
message2 (effectivelyFinal: false, flags: 8589934592)
message1 (effectivelyFinal: false, flags: 8589934592)
args1 (effectivelyFinal: false, flags: 25769803776)
```

same flags as for `checkerBugBad2`

reproduced in jdks:
```
openjdk version "17.0.12" 2024-07-16 LTS
OpenJDK Runtime Environment Zulu17.52+17-CA (build 17.0.12+7-LTS)
OpenJDK 64-Bit Server VM Zulu17.52+17-CA (build 17.0.12+7-LTS, mixed mode, sharing)
```
and
```
openjdk version "21.0.4" 2024-07-16 LTS
OpenJDK Runtime Environment Zulu21.36+17-CA (build 21.0.4+7-LTS)
OpenJDK 64-Bit Server VM Zulu21.36+17-CA (build 21.0.4+7-LTS, mixed mode, sharing)
```